### PR TITLE
fixed warning 31: moana.ml was being linked twice.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-ocamlfind ocamlc -g -o moanaml -thread -linkpkg -package core,sqlite3,yojson,lwt,lwt.unix,irmin,irmin.unix msqlite.ml \
-  config.ml moana.mli moana.ml moana_lists.ml moana_irmin.ml tests.ml moana.ml main.ml
+ocamlfind ocamlc -g -o moanaml -thread -linkpkg \
+  -package core,yojson,lwt,lwt.unix,irmin,irmin.unix,sqlite3 \
+  msqlite.ml config.ml moana.mli moana.ml moana_lists.ml moana_irmin.ml \
+  tests.ml main.ml
 
 ./moanaml


### PR DESCRIPTION
ocamlc allows this, but not ocamlopt -- for more background on this see http://caml.inria.fr/mantis/print_bug_page.php?bug_id=5461
